### PR TITLE
Change plottool to plottool_ibeis in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIREMENTS        = [
     'torch',
     'numpy',
     'matplotlib',
-    'plottool',
+    'plottool_ibeis',
     'utool',
     'vtool',
     'dtool',


### PR DESCRIPTION
`plottool` has been renamed to `plottool_ibeis` so need to update the
dependencies in setup.py to install the correct package.