### PR TITLE
Rename wbia to wildbook-ia in requirements files

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -8,6 +8,6 @@ torch
 torchvision
 # cv2
 tqdm
-wbia
 wbia-utool
 wbia-vtool
+wildbook-ia


### PR DESCRIPTION
We changed the distribution name from "wbia" to "wildbook-ia".